### PR TITLE
Include new example covering merge operation

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,21 @@
+name: Merge operation
+
+on: push
+
+jobs:
+  convert_via_pandoc:
+    runs-on: ubuntu-18.04
+    steps:
+      - run: echo "# Test A" > input_A.md  # create an example file
+      - run: echo "# Test B" > input_B.md
+      - run : |
+          echo ls *.md
+          echo ::set-env name=FILELIST::$(ls *.md)
+          mkdir merge
+      - uses: docker://pandoc/core:2.9
+        with:
+          args: -f markdown --toc --top-level-division=chapter --output=merge/result.pdf ${{ env.FILELIST }}
+      - uses: actions/upload-artifact@master
+        with:
+          name: merge
+          path: merge

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -12,7 +12,7 @@ jobs:
           echo ls *.md
           echo ::set-env name=FILELIST::$(ls *.md)
           mkdir merge
-      - uses: docker://pandoc/core:2.9
+      - uses: docker://pandoc/latex:2.9
         with:
           args: -f markdown --toc --top-level-division=chapter --output=merge/result.pdf ${{ env.FILELIST }}
       - uses: actions/upload-artifact@master

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -9,7 +9,7 @@ jobs:
       - run: echo "# Test A" > input_A.md  # create an example file
       - run: echo "# Test B" > input_B.md
       - run : |
-          echo ls *.md
+          ls *.md
           echo ::set-env name=FILELIST::$(ls *.md)
           mkdir merge
       - uses: docker://pandoc/latex:2.9

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ jobs:
       - run: echo "# Test A" > input_A.md  # create an example file
       - run: echo "# Test B" > input_B.md
       - run : |
-          echo ls *.md
+          ls *.md
           echo ::set-env name=FILELIST::$(ls *.md)
           mkdir merge
       - uses: docker://pandoc/latex:2.9

--- a/README.md
+++ b/README.md
@@ -105,3 +105,39 @@ jobs:
           name: output
           path: output
 ```
+
+## Pandoc merge operations for multiple input files
+
+Pandoc allows merging multiple input files in a single output file. If you
+intend to apply the GitHub-action on an unknown collection of files, it is
+necessary to pass a dynamically aggregated list of files to pandoc. The easiest
+way to transport the names is an environmental variable.
+
+To illustrate the mechanism, we generate two files `input_A.md` and
+`input_B.md`. The second step prints the files and stores their names in a
+variable `FILELIST`. This is a global environmental variable that can be
+accessed from each step (in contrast to individual `env` settings).
+
+```
+name: Merge operation
+
+on: push
+
+jobs:
+  convert_via_pandoc:
+    runs-on: ubuntu-18.04
+    steps:
+      - run: echo "# Test A" > input_A.md  # create an example file
+      - run: echo "# Test B" > input_B.md
+      - run : |
+          echo ls *.md
+          echo ::set-env name=FILELIST::$(ls *.md)
+          mkdir merge
+      - uses: docker://pandoc/core:2.9
+        with:
+          args: -f markdown --toc --top-level-division=chapter --output=merge/result.pdf ${{ env.FILELIST }}
+      - uses: actions/upload-artifact@master
+        with:
+          name: merge
+          path: merge
+```

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ jobs:
           echo ls *.md
           echo ::set-env name=FILELIST::$(ls *.md)
           mkdir merge
-      - uses: docker://pandoc/core:2.9
+      - uses: docker://pandoc/latex:2.9
         with:
           args: -f markdown --toc --top-level-division=chapter --output=merge/result.pdf ${{ env.FILELIST }}
       - uses: actions/upload-artifact@master


### PR DESCRIPTION
Hi maxheld83,
many thanks for your GitHub pandoc examples! That was a great support!
I added an example managing a merge process for varying number of unknown input files. The action extracts the file names, stores them in an environment variable and evaluates this list in the args list of pandoc. 
Sebastian 