### PR TITLE
Use the `GITHUB_OUTPUT` environment file instead of `set-output`

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -14,7 +14,7 @@ jobs:
           echo "dolor sit amet" > lorem_2.md
           mkdir output  # create output dir
           # this will also include README.md
-          echo "files=$(printf '"%s" ' *.md)" >> $GITHUB_OUTPUT
+          echo "files=$(printf '"%s" ' *.md)" > $GITHUB_OUTPUT
       - uses: docker://pandoc/latex:2.9
         with:
           args: --output=output/result.pdf ${{ steps.files_list.outputs.files }}

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -14,7 +14,7 @@ jobs:
           echo "dolor sit amet" > lorem_2.md
           mkdir output  # create output dir
           # this will also include README.md
-          echo "::set-output name=files::$(printf '"%s" ' *.md)"
+          echo "files=$(printf '"%s" ' *.md)" >> $GITHUB_OUTPUT
       - uses: docker://pandoc/latex:2.9
         with:
           args: --output=output/result.pdf ${{ steps.files_list.outputs.files }}

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ jobs:
           echo "dolor sit amet" > lorem_2.md
           mkdir output  # create output dir
           # this will also include README.md
-          echo "files=$(printf '"%s" ' *.md)" >> $GITHUB_OUTPUT
+          echo "files=$(printf '"%s" ' *.md)" > $GITHUB_OUTPUT
 
       - uses: docker://pandoc/latex:2.9
         with:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ jobs:
           echo "dolor sit amet" > lorem_2.md
           mkdir output  # create output dir
           # this will also include README.md
-          echo "::set-output name=files::$(printf '"%s" ' *.md)"
+          echo "files=$(printf '"%s" ' *.md)" >> $GITHUB_OUTPUT
 
       - uses: docker://pandoc/latex:2.9
         with:


### PR DESCRIPTION
In June, the `set-output` workflow command is being depreciated in favour of the environment file `GITHUB_OUTPUT`. This should be used in the advanced action to avoid any future errors.

See [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) for more information.

Thanks!